### PR TITLE
Add new delivery truck to seed data and update truck rule

### DIFF
--- a/config/app/resources/data/default.json
+++ b/config/app/resources/data/default.json
@@ -97,10 +97,10 @@
       ]
     },
     {
-      "Id": "default_Truck_Temperature_High",
-      "Name": "Higher than normal cargo temperature",
+      "Id": "default_Truck_Temperature_Low",
+      "Name": "Lower than normal cargo temperature",
       "Enabled": true,
-      "Description": "Cargo temperature is > 45 degrees",
+      "Description": "Cargo temperature is < 50 degrees",
       "GroupId": "default_Trucks",
       "Severity": "Warning",
       "Calculation": "Average",
@@ -108,8 +108,8 @@
       "Conditions": [
         {
           "Field": "temperature",
-          "Operator": "GreaterThan",
-          "Value": "45"
+          "Operator": "LessThan",
+          "Value": "50"
         }
       ]
     },
@@ -165,11 +165,11 @@
       "Count": 1
     },
     {
-      "Id": "truck-01",
+      "Id": "delivery-truck-01",
       "Count": 1
     },
     {
-      "Id": "truck-02",
+      "Id": "delivery-truck-02",
       "Count": 1
     }
   ]


### PR DESCRIPTION
The Time Series Insights Demo adds a new device model that can be found here:
https://github.com/Azure/device-simulation-dotnet/blob/master/Services/data/devicemodels/delivery-truck-01.json

This device needs to be started with the seed data simulation & the rule needs to be updated for the demo. 