### PR TITLE
Add optional labels in a deployment for package and device group name

### DIFF
--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Deployments.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Deployments.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.iotsolutions.iothubmanager.services.helpers.QueryCond
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentServiceListModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentServiceModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentStatus;
+import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeviceGroup;
 import com.microsoft.azure.sdk.iot.service.Configuration;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin;
@@ -173,8 +174,8 @@ public final class Deployments implements IDeployments {
     public CompletionStage<DeploymentServiceModel> createAsync(DeploymentServiceModel deployment) throws
             InvalidInputException {
         // Required labels
-        this.verifyDeploymentArgument(DEVICE_GROUP_ID_PARAM, deployment.getDeviceGroupId());
-        this.verifyDeploymentArgument(DEVICE_GROUP_QUERY_PARAM, deployment.getDeviceGroupQuery());
+        this.verifyDeploymentArgument(DEVICE_GROUP_ID_PARAM, deployment.getDeviceGroup().getId());
+        this.verifyDeploymentArgument(DEVICE_GROUP_QUERY_PARAM, deployment.getDeviceGroup().getQuery());
         this.verifyDeploymentArgument(NAME_PARAM, deployment.getName());
         this.verifyDeploymentArgument(PACKAGE_CONTENT_PARAM, deployment.getPackageContent());
 
@@ -296,7 +297,9 @@ public final class Deployments implements IDeployments {
         final Configuration pkgConfiguration = fromJson(Json.parse(packageContent), Configuration.class);
         edgeConfiguration.setContent(pkgConfiguration.getContent());
 
-        final String query = QueryConditionTranslator.ToQueryString(deployment.getDeviceGroupQuery());
+        final DeviceGroup deploymentGroup = deployment.getDeviceGroup();
+        final String dvcGroupQuery = deploymentGroup.getQuery();
+        final String query = QueryConditionTranslator.ToQueryString(dvcGroupQuery);
         edgeConfiguration.setTargetCondition(query);
         edgeConfiguration.setPriority(deployment.getPriority());
         edgeConfiguration.setEtag("");
@@ -308,12 +311,12 @@ public final class Deployments implements IDeployments {
 
         // Required labels
         labels.put(DEPLOYMENT_NAME_LABEL, deployment.getName());
-        labels.put(DEPLOYMENT_GROUP_ID_LABEL, deployment.getDeviceGroupId());
+        labels.put(DEPLOYMENT_GROUP_ID_LABEL, deploymentGroup.getId());
         labels.put(RM_CREATED_LABEL, Boolean.TRUE.toString());
 
         // Add optional labels
-        if (deployment.getDeviceGroupName() != null) {
-            labels.put(DEPLOYMENT_GROUP_NAME_LABEL, deployment.getDeviceGroupName());
+        if (deploymentGroup.getName() != null) {
+            labels.put(DEPLOYMENT_GROUP_NAME_LABEL, deploymentGroup.getName());
         }
         if (deployment.getPackageName() != null) {
             labels.put(DEPLOYMENT_PACKAGE_NAME_LABEL, deployment.getPackageName());

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Deployments.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Deployments.java
@@ -48,11 +48,15 @@ public final class Deployments implements IDeployments {
 
     private static final String DEPLOYMENT_NAME_LABEL = "Name";
     private static final String DEPLOYMENT_GROUP_ID_LABEL = "DeviceGroupId";
+    private static final String DEPLOYMENT_GROUP_NAME_LABEL = "DeviceGroupName";
+    private static final String DEPLOYMENT_PACKAGE_NAME_LABEL = "PackageName";
     private static final String RM_CREATED_LABEL = "RMDeployment";
+
     private static final String DEVICE_GROUP_ID_PARAM = "deviceGroupId";
     private static final String DEVICE_GROUP_QUERY_PARAM = "deviceGroupQuery";
     private static final String NAME_PARAM = "name";
     private static final String PACKAGE_CONTENT_PARAM = "packageContent";
+
     private static final String SCHEMA_VERSION = "schemaVersion";
     private static final String APPLIED_DEVICES_QUERY =
             "moduleId = '$edgeAgent' and configurations.[[%s]].status = 'Applied'";
@@ -168,11 +172,11 @@ public final class Deployments implements IDeployments {
     @Override
     public CompletionStage<DeploymentServiceModel> createAsync(DeploymentServiceModel deployment) throws
             InvalidInputException {
+        // Required labels
         this.verifyDeploymentArgument(DEVICE_GROUP_ID_PARAM, deployment.getDeviceGroupId());
         this.verifyDeploymentArgument(DEVICE_GROUP_QUERY_PARAM, deployment.getDeviceGroupQuery());
         this.verifyDeploymentArgument(NAME_PARAM, deployment.getName());
         this.verifyDeploymentArgument(PACKAGE_CONTENT_PARAM, deployment.getPackageContent());
-        this.verifyDeploymentArgument(DEVICE_GROUP_ID_PARAM, deployment.getDeviceGroupId());
 
         if (deployment.getPriority() < 0) {
             throw new InvalidInputException("Invalid input. A priority should be provided greater than 0.");
@@ -302,9 +306,19 @@ public final class Deployments implements IDeployments {
         }
         final Map<String, String> labels = edgeConfiguration.getLabels();
 
+        // Required labels
         labels.put(DEPLOYMENT_NAME_LABEL, deployment.getName());
         labels.put(DEPLOYMENT_GROUP_ID_LABEL, deployment.getDeviceGroupId());
         labels.put(RM_CREATED_LABEL, Boolean.TRUE.toString());
+
+        // Add optional labels
+        if (deployment.getDeviceGroupName() != null) {
+            labels.put(DEPLOYMENT_GROUP_NAME_LABEL, deployment.getDeviceGroupName());
+        }
+        if (deployment.getPackageName() != null) {
+            labels.put(DEPLOYMENT_PACKAGE_NAME_LABEL, deployment.getPackageName());
+        }
+
         return edgeConfiguration;
     }
 

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeploymentServiceModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeploymentServiceModel.java
@@ -18,9 +18,7 @@ public class DeploymentServiceModel {
 
     private String id;
     private String name;
-    private String deviceGroupId;
-    private String deviceGroupName;
-    private String deviceGroupQuery;
+    private DeviceGroup deviceGroup;
     private String packageContent;
     private String packageName;
     private int priority;
@@ -29,22 +27,19 @@ public class DeploymentServiceModel {
     private DeploymentMetrics deploymentMetrics;
 
     public DeploymentServiceModel(final String name,
-                                  final String deviceGroupId,
-                                  final String deviceGroupName,
-                                  final String deviceGroupQuery,
+                                  final DeviceGroup deviceGroup,
                                   final String packageContent,
                                   final String packageName,
                                   final int priority,
                                   final DeploymentType type) {
-        this.deviceGroupId = deviceGroupId;
-        this.deviceGroupName = deviceGroupName;
-        this.deviceGroupQuery = deviceGroupQuery;
+        this.deviceGroup = deviceGroup;
         this.packageContent = packageContent;
         this.name = name;
         this.packageName = packageName;
         this.priority = priority;
         this.type = type;
     }
+
     public DeploymentServiceModel(Configuration config) throws InvalidInputException {
         if (StringUtils.isEmpty(config.getId())) {
             throw new InvalidInputException("Invalid id provided");
@@ -60,11 +55,15 @@ public class DeploymentServiceModel {
 
         this.id = config.getId();
         this.name = config.getLabels().get(DEPLOYMENT_NAME_LABEL);
-        this.deviceGroupId = config.getLabels().get(DEPLOYMENT_GROUP_ID_LABEL);
 
+        String deviceGroupId = config.getLabels().get(DEPLOYMENT_GROUP_ID_LABEL);
+        String deviceGroupName = StringUtils.EMPTY;
         if (config.getLabels().containsKey(DEPLOYMENT_GROUP_NAME_LABEL)) {
-            this.deviceGroupName = config.getLabels().get(DEPLOYMENT_GROUP_NAME_LABEL);
+            deviceGroupName = config.getLabels().get(DEPLOYMENT_GROUP_NAME_LABEL);
         }
+        this.deviceGroup = new DeviceGroup(deviceGroupId, deviceGroupName, null);
+
+        this.packageName = StringUtils.EMPTY;
         if (config.getLabels().containsKey(DEPLOYMENT_PACKAGE_NAME_LABEL)) {
             this.packageName = config.getLabels().get(DEPLOYMENT_PACKAGE_NAME_LABEL);
         }
@@ -83,21 +82,7 @@ public class DeploymentServiceModel {
         return this.name;
     }
 
-    public String getDeviceGroupId() {
-        return this.deviceGroupId;
-    }
-
-    public String getDeviceGroupName() {
-        return this.deviceGroupName;
-    }
-
-    public String getDeviceGroupQuery() {
-        return this.deviceGroupQuery;
-    }
-
-    public String getPackageContent() {
-        return this.packageContent;
-    }
+    public String getPackageContent() { return this.packageContent; }
 
     public String getPackageName() {
         return this.packageName;
@@ -106,6 +91,8 @@ public class DeploymentServiceModel {
     public String getCreatedDateTimeUtc() {
         return this.createdDateTimeUtc;
     }
+
+    public DeviceGroup getDeviceGroup() { return this.deviceGroup; }
 
     public int getPriority() {
         return this.priority;

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeploymentServiceModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeploymentServiceModel.java
@@ -12,28 +12,36 @@ public class DeploymentServiceModel {
 
     private final static String DEPLOYMENT_NAME_LABEL = "Name";
     private final static String DEPLOYMENT_GROUP_ID_LABEL = "DeviceGroupId";
+    private final static String DEPLOYMENT_GROUP_NAME_LABEL = "DeviceGroupName";
+    private final static String DEPLOYMENT_PACKAGE_NAME_LABEL = "PackageName";
     private final static String DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     private String id;
     private String name;
-    private String packageContent;
     private String deviceGroupId;
+    private String deviceGroupName;
     private String deviceGroupQuery;
-    private String createdDateTimeUtc;
+    private String packageContent;
+    private String packageName;
     private int priority;
+    private String createdDateTimeUtc;
     private DeploymentType type;
     private DeploymentMetrics deploymentMetrics;
 
     public DeploymentServiceModel(final String name,
                                   final String deviceGroupId,
+                                  final String deviceGroupName,
                                   final String deviceGroupQuery,
                                   final String packageContent,
+                                  final String packageName,
                                   final int priority,
                                   final DeploymentType type) {
         this.deviceGroupId = deviceGroupId;
+        this.deviceGroupName = deviceGroupName;
         this.deviceGroupQuery = deviceGroupQuery;
         this.packageContent = packageContent;
         this.name = name;
+        this.packageName = packageName;
         this.priority = priority;
         this.type = type;
     }
@@ -53,6 +61,14 @@ public class DeploymentServiceModel {
         this.id = config.getId();
         this.name = config.getLabels().get(DEPLOYMENT_NAME_LABEL);
         this.deviceGroupId = config.getLabels().get(DEPLOYMENT_GROUP_ID_LABEL);
+
+        if (config.getLabels().containsKey(DEPLOYMENT_GROUP_NAME_LABEL)) {
+            this.deviceGroupName = config.getLabels().get(DEPLOYMENT_GROUP_NAME_LABEL);
+        }
+        if (config.getLabels().containsKey(DEPLOYMENT_PACKAGE_NAME_LABEL)) {
+            this.packageName = config.getLabels().get(DEPLOYMENT_PACKAGE_NAME_LABEL);
+        }
+
         this.createdDateTimeUtc =  this.formatDateTimeToUTC(config.getCreatedTimeUtc());
         this.priority = config.getPriority();
         this.type = DeploymentType.edgeManifest;
@@ -67,15 +83,25 @@ public class DeploymentServiceModel {
         return this.name;
     }
 
-    public String getPackageContent() {
-        return this.packageContent;
-    }
-
     public String getDeviceGroupId() {
         return this.deviceGroupId;
     }
 
-    public String getDeviceGroupQuery() { return this.deviceGroupQuery; }
+    public String getDeviceGroupName() {
+        return this.deviceGroupName;
+    }
+
+    public String getDeviceGroupQuery() {
+        return this.deviceGroupQuery;
+    }
+
+    public String getPackageContent() {
+        return this.packageContent;
+    }
+
+    public String getPackageName() {
+        return this.packageName;
+    }
 
     public String getCreatedDateTimeUtc() {
         return this.createdDateTimeUtc;

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceGroup.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceGroup.java
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package com.microsoft.azure.iotsolutions.iothubmanager.services.models;
+
+public class DeviceGroup {
+    private final String id;
+    private final String name;
+    private final String query;
+
+    public DeviceGroup(String id, String name, String query) {
+        this.id = id;
+        this.name = name;
+        this.query = query;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getQuery() {
+        return this.query;
+    }
+}

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeploymentApiModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeploymentApiModel.java
@@ -5,6 +5,7 @@ package com.microsoft.azure.iotsolutions.iothubmanager.webservice.v1.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentServiceModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentType;
+import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeviceGroup;
 
 public class DeploymentApiModel {
     private String id;
@@ -37,9 +38,9 @@ public class DeploymentApiModel {
     public DeploymentApiModel(DeploymentServiceModel serviceModel) {
         this.createdDateTimeUtc = serviceModel.getCreatedDateTimeUtc();
         this.id = serviceModel.getId();
-        this.deviceGroupId = serviceModel.getDeviceGroupId();
-        this.deviceGroupName = serviceModel.getDeviceGroupName();
-        this.deviceGroupQuery = serviceModel.getDeviceGroupQuery();
+        this.deviceGroupId = serviceModel.getDeviceGroup().getId();
+        this.deviceGroupName = serviceModel.getDeviceGroup().getName();
+        this.deviceGroupQuery = serviceModel.getDeviceGroup().getQuery();
         this.name = serviceModel.getName();
         this.packageContent = serviceModel.getPackageContent();
         this.packageName = serviceModel.getPackageName();
@@ -101,12 +102,10 @@ public class DeploymentApiModel {
 
     public DeploymentServiceModel toServiceModel() {
         return new DeploymentServiceModel(this.name,
-                                          this.deviceGroupId,
-                                          this.deviceGroupName,
-                                          this.deviceGroupQuery,
-                                          this.packageContent,
-                                          this.packageName,
-                                          this.priority,
-                                          this.type);
+                new DeviceGroup(this.deviceGroupId, this.deviceGroupName, this.deviceGroupQuery),
+                this.packageContent,
+                this.packageName,
+                this.priority,
+                this.type);
     }
 }

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeploymentApiModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeploymentApiModel.java
@@ -11,21 +11,25 @@ public class DeploymentApiModel {
     private String name;
     private String createdDateTimeUtc;
     private String deviceGroupId;
+    private String deviceGroupName;
     private String deviceGroupQuery;
     private String packageContent;
+    private String packageName;
     private int priority;
     private DeploymentType type;
     private DeploymentMetricsApiModel metrics;
 
     public DeploymentApiModel() {}
 
-    public DeploymentApiModel(String deploymentName, String deviceGroupId,
-                              String deviceGroupQuery, String packageContent, int priority,
-                              DeploymentType deploymentType) {
+    public DeploymentApiModel(String deploymentName, String deviceGroupId, String deviceGroupName,
+                              String deviceGroupQuery, String packageContent, String packageName,
+                              int priority, DeploymentType deploymentType) {
         this.name = deploymentName;
         this.deviceGroupId = deviceGroupId;
+        this.deviceGroupName = deviceGroupName;
         this.deviceGroupQuery = deviceGroupQuery;
         this.packageContent = packageContent;
+        this.packageName = packageName;
         this.priority = priority;
         this.type = deploymentType;
     }
@@ -34,9 +38,11 @@ public class DeploymentApiModel {
         this.createdDateTimeUtc = serviceModel.getCreatedDateTimeUtc();
         this.id = serviceModel.getId();
         this.deviceGroupId = serviceModel.getDeviceGroupId();
+        this.deviceGroupName = serviceModel.getDeviceGroupName();
         this.deviceGroupQuery = serviceModel.getDeviceGroupQuery();
         this.name = serviceModel.getName();
         this.packageContent = serviceModel.getPackageContent();
+        this.packageName = serviceModel.getPackageName();
         this.priority = serviceModel.getPriority();
         this.type = serviceModel.getType();
         this.metrics = new DeploymentMetricsApiModel(serviceModel.getDeploymentMetrics());
@@ -62,6 +68,9 @@ public class DeploymentApiModel {
         return this.deviceGroupId;
     }
 
+    @JsonProperty("DeviceGroupName")
+    public String getDeviceGroupName() { return this.deviceGroupName; }
+
     @JsonProperty("DeviceGroupQuery")
     public String getDeviceGroupQuery() {
         return this.deviceGroupQuery;
@@ -71,6 +80,9 @@ public class DeploymentApiModel {
     public String getPackageContent() {
         return this.packageContent;
     }
+
+    @JsonProperty("PackageName")
+    public String getPackageName() { return this.packageName; }
 
     @JsonProperty("Priority")
     public int getPriority() {
@@ -90,8 +102,10 @@ public class DeploymentApiModel {
     public DeploymentServiceModel toServiceModel() {
         return new DeploymentServiceModel(this.name,
                                           this.deviceGroupId,
+                                          this.deviceGroupName,
                                           this.deviceGroupQuery,
                                           this.packageContent,
+                                          this.packageName,
                                           this.priority,
                                           this.type);
     }

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/DeploymentsTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/DeploymentsTest.java
@@ -6,6 +6,7 @@ import com.microsoft.azure.iotsolutions.iothubmanager.services.exceptions.Invali
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentServiceListModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentServiceModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentType;
+import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeviceGroup;
 import com.microsoft.azure.sdk.iot.service.Configuration;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin;
@@ -80,13 +81,11 @@ public class DeploymentsTest {
         final String packageContent = addPackageContent ? Json.toJson(config).toString() : StringUtils.EMPTY;
 
         final DeploymentServiceModel model = new DeploymentServiceModel(deploymentName,
-                                                                        deviceGroupId,
-                                                                        StringUtils.EMPTY,
-                                                                        dvcGroupQuery,
-                                                                        packageContent,
-                                                                        StringUtils.EMPTY,
-                                                                        priority,
-                                                                        DeploymentType.edgeManifest);
+                new DeviceGroup(deviceGroupId, StringUtils.EMPTY, dvcGroupQuery),
+                packageContent,
+                StringUtils.EMPTY,
+                priority,
+                DeploymentType.edgeManifest);
 
         final IsValidConfiguration isValidConfig = new IsValidConfiguration(deploymentName, deviceGroupId);
         when(this.registry.addConfiguration(argThat(isValidConfig))).thenReturn(config);
@@ -99,7 +98,7 @@ public class DeploymentsTest {
             DeploymentServiceModel createdDeployment = this.deployments.createAsync(model).toCompletableFuture().get();
             assertEquals(registryManagerDeploymentId, createdDeployment.getId());
             assertEquals(deploymentName, createdDeployment.getName());
-            assertEquals(deviceGroupId, createdDeployment.getDeviceGroupId());
+            assertEquals(deviceGroupId, createdDeployment.getDeviceGroup().getId());
             assertEquals(priority, createdDeployment.getPriority());
         }
     }
@@ -125,8 +124,8 @@ public class DeploymentsTest {
         {
             final DeploymentServiceModel deployment = returnedDeployments.getItems().get(i);
             assertEquals("deployment" + i, deployment.getName());
-            assertEquals("dvcGroupId" + i, deployment.getDeviceGroupId());
-            assertEquals("dvcGroupName" + i, deployment.getDeviceGroupName());
+            assertEquals("dvcGroupId" + i, deployment.getDeviceGroup().getId());
+            assertEquals("dvcGroupName" + i, deployment.getDeviceGroup().getName());
             assertEquals("packageName" + i, deployment.getPackageName());
         }
     }
@@ -148,8 +147,8 @@ public class DeploymentsTest {
         assertEquals(1, returnedDeployments.getItems().size());
         final DeploymentServiceModel deployment = returnedDeployments.getItems().get(0);
         assertEquals("deployment0", returnedDeployments.getItems().get(0).getName());
-        assertEquals("dvcGroupId0", deployment.getDeviceGroupId());
-        assertEquals("dvcGroupName0", deployment.getDeviceGroupName());
+        assertEquals("dvcGroupId0", deployment.getDeviceGroup().getId());
+        assertEquals("dvcGroupName0", deployment.getDeviceGroup().getName());
         assertEquals("packageName0", deployment.getPackageName());
     }
 

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/controllers/DeploymentsControllerTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/controllers/DeploymentsControllerTest.java
@@ -8,6 +8,7 @@ import com.microsoft.azure.iotsolutions.iothubmanager.services.helpers.TestUtils
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentServiceListModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentServiceModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentType;
+import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeviceGroup;
 import com.microsoft.azure.iotsolutions.iothubmanager.webservice.v1.models.DeploymentApiModel;
 import com.microsoft.azure.iotsolutions.iothubmanager.webservice.v1.models.DeploymentListApiModel;
 import junitparams.JUnitParamsRunner;
@@ -58,9 +59,7 @@ public class DeploymentsControllerTest {
     public void getDeploymentTest() throws Exception {
         // Arrange
         DeploymentServiceModel deploymentModel = new DeploymentServiceModel(DEPLOYMENT_NAME,
-                                                                            DEVICE_GROUP_ID,
-                                                                            DEVICE_GROUP_NAME,
-                                                                            DEVICE_GROUP_QUERY,
+                new DeviceGroup(DEVICE_GROUP_ID, DEVICE_GROUP_NAME, DEVICE_GROUP_QUERY),
                                                                             PACKAGE_CONTENT,
                                                                             PACKAGE_NAME,
                                                                             PRIORITY,
@@ -86,13 +85,11 @@ public class DeploymentsControllerTest {
         List<DeploymentServiceModel> deploymentsList = new ArrayList<>();
         for(int i = 0; i < numDeployments; i++) {
             DeploymentServiceModel dep = new DeploymentServiceModel(DEPLOYMENT_NAME + i,
-                                                                    DEVICE_GROUP_ID + i,
-                                                                    DEVICE_GROUP_NAME + i,
-                                                                    DEVICE_GROUP_QUERY + i,
-                                                                    PACKAGE_CONTENT + i,
-                                                                    PACKAGE_NAME + i,
-                                                                    PRIORITY + i,
-                                                                    DeploymentType.edgeManifest);
+                    new DeviceGroup(DEVICE_GROUP_ID + i,DEVICE_GROUP_NAME + i, DEVICE_GROUP_QUERY + i),
+                    PACKAGE_CONTENT + i,
+                    PACKAGE_NAME + i,
+                    PRIORITY + i,
+                    DeploymentType.edgeManifest);
             deploymentsList.add(dep);
         }
 
@@ -132,8 +129,11 @@ public class DeploymentsControllerTest {
                 deviceGroupQuery, packageContent, priority);
 
         final DeploymentServiceModel deploymentMode = new DeploymentServiceModel(deploymentName,
-                deviceGroupId, StringUtils.EMPTY, packageContent, StringUtils.EMPTY,
-                deploymentName, priority, DeploymentType.edgeManifest);
+                new DeviceGroup(deviceGroupId, StringUtils.EMPTY, deviceGroupQuery),
+                StringUtils.EMPTY,
+                packageContent,
+                priority,
+                DeploymentType.edgeManifest);
         when(this.deployments.createAsync(argThat(matchesDeployment))).thenReturn(completedFuture
                 (deploymentMode));
 
@@ -177,8 +177,8 @@ public class DeploymentsControllerTest {
         @Override
         public boolean matches(DeploymentServiceModel config) {
             return this.deploymentName.equals(config.getName()) &&
-                    this.deviceGroupId.equals(config.getDeviceGroupId()) &&
-                    this.deviceGroupQuery.equals(config.getDeviceGroupQuery()) &&
+                    this.deviceGroupId.equals(config.getDeviceGroup().getId()) &&
+                    this.deviceGroupQuery.equals(config.getDeviceGroup().getQuery()) &&
                     this.packageContent.equals(config.getPackageContent()) &&
                     this.priority == config.getPriority();
         }

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/controllers/DeploymentsControllerTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/controllers/DeploymentsControllerTest.java
@@ -60,10 +60,10 @@ public class DeploymentsControllerTest {
         // Arrange
         DeploymentServiceModel deploymentModel = new DeploymentServiceModel(DEPLOYMENT_NAME,
                 new DeviceGroup(DEVICE_GROUP_ID, DEVICE_GROUP_NAME, DEVICE_GROUP_QUERY),
-                                                                            PACKAGE_CONTENT,
-                                                                            PACKAGE_NAME,
-                                                                            PRIORITY,
-                                                                            DeploymentType.edgeManifest);
+                PACKAGE_CONTENT,
+                PACKAGE_NAME,
+                PRIORITY,
+                DeploymentType.edgeManifest);
 
         when(this.deployments.getAsync(DEPLOYMENT_ID, false)).thenReturn(completedFuture(deploymentModel));
 

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/controllers/DeploymentsControllerTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/controllers/DeploymentsControllerTest.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.iotsolutions.iothubmanager.webservice.v1.models.Deplo
 import com.microsoft.azure.iotsolutions.iothubmanager.webservice.v1.models.DeploymentListApiModel;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -33,8 +34,10 @@ import static org.mockito.Mockito.when;
 public class DeploymentsControllerTest {
     private static final String DEPLOYMENT_NAME = "depname";
     private static final String DEVICE_GROUP_ID = "dvcGroupId";
+    private static final String DEVICE_GROUP_NAME = "dvcGroupName";
     private static final String DEVICE_GROUP_QUERY = "dvcGroupQuery";
     private static final String PACKAGE_CONTENT = "packageContent";
+    private static final String PACKAGE_NAME = "packageName";
     private static final String DEPLOYMENT_ID = "dvcGroupId-packageId";
     private static final int PRIORITY = 10;
 
@@ -56,8 +59,10 @@ public class DeploymentsControllerTest {
         // Arrange
         DeploymentServiceModel deploymentModel = new DeploymentServiceModel(DEPLOYMENT_NAME,
                                                                             DEVICE_GROUP_ID,
+                                                                            DEVICE_GROUP_NAME,
                                                                             DEVICE_GROUP_QUERY,
                                                                             PACKAGE_CONTENT,
+                                                                            PACKAGE_NAME,
                                                                             PRIORITY,
                                                                             DeploymentType.edgeManifest);
 
@@ -82,8 +87,10 @@ public class DeploymentsControllerTest {
         for(int i = 0; i < numDeployments; i++) {
             DeploymentServiceModel dep = new DeploymentServiceModel(DEPLOYMENT_NAME + i,
                                                                     DEVICE_GROUP_ID + i,
+                                                                    DEVICE_GROUP_NAME + i,
                                                                     DEVICE_GROUP_QUERY + i,
                                                                     PACKAGE_CONTENT + i,
+                                                                    PACKAGE_NAME + i,
                                                                     PRIORITY + i,
                                                                     DeploymentType.edgeManifest);
             deploymentsList.add(dep);
@@ -103,6 +110,8 @@ public class DeploymentsControllerTest {
             final DeploymentApiModel deployment = deployments.getItems().get(i);
             assertEquals(DEPLOYMENT_NAME + i, deployment.getName());
             assertEquals(DEVICE_GROUP_ID + i, deployment.getDeviceGroupId());
+            assertEquals(DEVICE_GROUP_NAME + i, deployment.getDeviceGroupName());
+            assertEquals(PACKAGE_NAME + i, deployment.getPackageName());
             assertEquals(PRIORITY + i, deployment.getPriority());
         }
     }
@@ -123,13 +132,14 @@ public class DeploymentsControllerTest {
                 deviceGroupQuery, packageContent, priority);
 
         final DeploymentServiceModel deploymentMode = new DeploymentServiceModel(deploymentName,
-                deviceGroupId, packageContent,
+                deviceGroupId, StringUtils.EMPTY, packageContent, StringUtils.EMPTY,
                 deploymentName, priority, DeploymentType.edgeManifest);
         when(this.deployments.createAsync(argThat(matchesDeployment))).thenReturn(completedFuture
                 (deploymentMode));
 
         final DeploymentApiModel depApiModel = new DeploymentApiModel(deploymentName, deviceGroupId,
-                deviceGroupQuery, packageContent, priority, DeploymentType.edgeManifest);
+                StringUtils.EMPTY, deviceGroupQuery, packageContent, StringUtils.EMPTY, priority,
+                DeploymentType.edgeManifest);
 
         // Act
         TestUtils.setRequest(depApiModel);


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [x] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (Will do so when merging final feature).

# Description of the change
Adds additional labels for quick lookup of the device group name and package name to help reflect how the deployment was created in our UI.

Java version of https://github.com/Azure/remote-monitoring-services-dotnet/pull/151.

# Motivation for the change
This helps because a package / device group could be deleted making look up of the package name impossible in the future.
