### PR TITLE
Update SDK to fix schemaVersion and getDevices bugs

### DIFF
--- a/config/build.sbt
+++ b/config/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= {
     ws,
 
     // https://github.com/Azure/azure-iot-sdk-java/releases
-    "com.microsoft.azure.sdk.iot" % "iot-service-client" % "1.15.0",
+    "com.microsoft.azure.sdk.iot" % "iot-service-client" % "1.15.1",
 
     // https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk
     "com.nimbusds" % "oauth2-oidc-sdk" % "5.36",

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Deployments.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Deployments.java
@@ -286,14 +286,7 @@ public final class Deployments implements IDeployments {
         final String deploymentId = UUID.randomUUID().toString();
         final Configuration edgeConfiguration = new Configuration(deploymentId);
 
-        String packageContent = deployment.getPackageContent();
-        JsonNode node = Json.parse(packageContent);
-        JsonNode schemaVersionNode = Json.parse(packageContent).get(SCHEMA_VERSION);
-        if (schemaVersionNode == null || StringUtils.isEmpty(schemaVersionNode.toString())) {
-            node = ((ObjectNode) node).put(SCHEMA_VERSION, "1.0");
-            packageContent = Json.toJson(node).toString();
-        }
-
+        final String packageContent = deployment.getPackageContent();
         final Configuration pkgConfiguration = fromJson(Json.parse(packageContent), Configuration.class);
         edgeConfiguration.setContent(pkgConfiguration.getContent());
 

--- a/iothub-manager/build.sbt
+++ b/iothub-manager/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= {
     ws,
 
     // https://github.com/Azure/azure-iot-sdk-java/releases
-    "com.microsoft.azure.sdk.iot" % "iot-service-client" % "1.15.0",
+    "com.microsoft.azure.sdk.iot" % "iot-service-client" % "1.15.1",
 
     // https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk
     "com.nimbusds" % "oauth2-oidc-sdk" % "5.36",


### PR DESCRIPTION
New SDK release to fix two bugs we were facing. 
- SchemaVersion being optional
- Our device properties not parsing due to max depth level.