### PR TITLE
Fix query which includes empty set

### DIFF
--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/QueryConditionTranslator.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/QueryConditionTranslator.java
@@ -49,7 +49,7 @@ public class QueryConditionTranslator {
         }
 
         if (clauses.size() == 0) {
-            return conditions.replace('\"', '\'').replaceAll("\\[\\s*\\]", "");
+            return conditions.replace('\"', '\'').replaceAll("^\\s*\\[\\s*\\]", "");
         } else {
             StringWriter sb = new StringWriter();
             for (QueryConditionClause clause : clauses) {

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/QueryConditionTranslatorTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/QueryConditionTranslatorTest.java
@@ -27,15 +27,17 @@ public class QueryConditionTranslatorTest {
         String conditions = "Tags.Building = 43 and Properties.Reported.Type = \"Chiller\"";
         String query = QueryConditionTranslator.ToQueryString(conditions);
         String expected = "Tags.Building = 43 and Properties.Reported.Type = 'Chiller'";
-        Assert.assertEquals(query, expected);
+        Assert.assertEquals(expected, query);
     }
 
     @Test()
     @Category({UnitTest.class})
     public void ToQueryEmptyStringTest() throws Exception {
-        Assert.assertEquals(QueryConditionTranslator.ToQueryString(""), "");
-        Assert.assertEquals(QueryConditionTranslator.ToQueryString("\"\""), "''");
-        Assert.assertEquals(QueryConditionTranslator.ToQueryString("[]"), "");
-        Assert.assertEquals(QueryConditionTranslator.ToQueryString("[  ]"), "");
+        Assert.assertEquals("", QueryConditionTranslator.ToQueryString(""));
+        Assert.assertEquals("''", QueryConditionTranslator.ToQueryString("\"\""));
+        Assert.assertEquals("", QueryConditionTranslator.ToQueryString("[]"));
+        Assert.assertEquals("", QueryConditionTranslator.ToQueryString("[  ]"));
+        Assert.assertEquals("", QueryConditionTranslator.ToQueryString("  [ ]"));
+        Assert.assertEquals("deviceId IN []", QueryConditionTranslator.ToQueryString("deviceId IN []"));
     }
 }


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Queries like "deviceId IN []" were throwing exceptions. While this isn't a very valuable query since it would always be empty throwing an exception isn't the right behavior. In .Net we return an empty list and this makes our Java repo do the same.

We can consider instead making empty queries return 404 not found instead as well possibly.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
...
