### PR TITLE
Add the ability to create an edge device

### DIFF
--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Devices.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Devices.java
@@ -171,6 +171,13 @@ public final class Devices implements IDevices {
     public CompletionStage<DeviceServiceModel> createAsync(
         final DeviceServiceModel device)
         throws InvalidInputException, ExternalDependencyException {
+        if (device.getIsEdgeDevice() &&
+                device.getAuthentication() != null &&
+                !device.getAuthentication().getAuthenticationType().equals(AuthenticationType.Sas))
+        {
+            throw new InvalidInputException("Edge devices only support symmetric key authentication.");
+        }
+
         if (device.getId() == null || device.getId().isEmpty()) {
             device.setId(UUID.randomUUID().toString());
         }

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/AuthenticationMechanismServiceModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/AuthenticationMechanismServiceModel.java
@@ -31,7 +31,7 @@ public class AuthenticationMechanismServiceModel {
                 this.secondaryKey = azureModel.getSymmetricKey().getSecondaryKey();
                 break;
             case SELF_SIGNED:
-                this.authenticationType = AuthenticationType.SelfSinged;
+                this.authenticationType = AuthenticationType.SelfSigned;
                 this.primaryThumbprint = azureModel.getPrimaryThumbprint();
                 this.secondaryThumbprint = azureModel.getSecondaryThumbprint();
                 break;
@@ -52,7 +52,7 @@ public class AuthenticationMechanismServiceModel {
                 this.secondaryKey = device.getSymmetricKey().getSecondaryKey();
                 break;
             case SELF_SIGNED:
-                this.authenticationType = AuthenticationType.SelfSinged;
+                this.authenticationType = AuthenticationType.SelfSigned;
                 this.primaryThumbprint = device.getPrimaryThumbprint();
                 this.secondaryThumbprint = device.getSecondaryThumbprint();
                 break;
@@ -115,7 +115,7 @@ public class AuthenticationMechanismServiceModel {
                 key.setSecondaryKey(this.secondaryKey);
                 auth = new AuthenticationMechanism(key);
                 break;
-            case SelfSinged:
+            case SelfSigned:
                 auth = new AuthenticationMechanism(this.primaryThumbprint, this.secondaryThumbprint);
                 auth.setAuthenticationType(com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED);
                 break;

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/AuthenticationType.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/AuthenticationType.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AuthenticationType {
     Sas(0),                     // Shared Access Key
-    SelfSinged(1),              // Self-signed certificate
+    SelfSigned(1),              // Self-signed certificate
     CertificateAuthority(2);    // Certificate Authority
 
     private final int value;
@@ -22,7 +22,7 @@ public enum AuthenticationType {
         switch(authenticationType) {
             case Sas:
                 return com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
-            case SelfSinged:
+            case SelfSigned:
                 return com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
             case CertificateAuthority:
                 return com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.CERTIFICATE_AUTHORITY;

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeviceRegistryApiModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeviceRegistryApiModel.java
@@ -21,6 +21,7 @@ public final class DeviceRegistryApiModel {
     private long c2DMessageCount = 0;
     private Date lastActivity = null;
     private boolean connected = false;
+    private boolean isEdgeDevice = false;
     private Date lastStatusUpdated = null;
     private AuthenticationMechanismApiModel authentication = null;
     private String ioTHubHostName = null;
@@ -47,6 +48,7 @@ public final class DeviceRegistryApiModel {
         this.lastActivity = device.getLastActivity().toDate();
         this.connected = device.getConnected();
         this.enabled = device.getEnabled();
+        this.isEdgeDevice = device.getIsEdgeDevice();
         this.lastStatusUpdated = device.getLastStatusUpdated().toDate();
         this.authentication = new AuthenticationMechanismApiModel(device.getAuthentication());
         this.ioTHubHostName = device.getIoTHubHostName();
@@ -85,6 +87,15 @@ public final class DeviceRegistryApiModel {
 
     public void setEnabled(Boolean value) {
         this.enabled = value;
+    }
+
+    @JsonProperty("IsEdgeDevice")
+    public boolean getIsEdgeDevice() {
+        return this.isEdgeDevice;
+    }
+
+    public void setIsEdgeDevice(Boolean isEdgeDevice) {
+        this.isEdgeDevice = isEdgeDevice;
     }
 
     @JsonProperty("C2DMessageCount")
@@ -190,6 +201,7 @@ public final class DeviceRegistryApiModel {
             new DateTime(this.lastActivity),
             this.connected,
             this.enabled,
+            this.isEdgeDevice,
             new DateTime(this.lastStatusUpdated),
             twinServiceModel,
             this.authentication == null ? null : this.authentication.toServiceModel(),

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/DevicesTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/DevicesTest.java
@@ -224,7 +224,7 @@ public class DevicesTest {
             put("Building", "Building40");
             put("Floor", "1F");
         }};
-        AuthenticationMechanismServiceModel authModel = new AuthenticationMechanismServiceModel(AuthenticationType.SelfSinged);
+        AuthenticationMechanismServiceModel authModel = new AuthenticationMechanismServiceModel(AuthenticationType.SelfSigned);
 
         TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, null, tags, true);
         DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, false, null,

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/DevicesTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/DevicesTest.java
@@ -171,7 +171,8 @@ public class DevicesTest {
 
         TwinProperties properties = new TwinProperties(desired, null);
         TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, properties, tags, true);
-        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, null, twin, null, null);
+        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, false, null,
+                twin, null, null);
         DeviceServiceModel newDevice = deviceService.createAsync(device).toCompletableFuture().get();
         TwinServiceModel newTwin = newDevice.getTwin();
         HashMap<String, Object> configMap = (HashMap) newTwin.getProperties().getDesired().get("Config");
@@ -201,7 +202,8 @@ public class DevicesTest {
         authModel.setSecondaryKey(key.getSecondaryKey());
 
         TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, null, tags, true);
-        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, null, twin, authModel, null);
+        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, false, null,
+                twin, authModel, null);
         DeviceServiceModel newDevice = deviceService.createAsync(device).toCompletableFuture().get();
 
         Assert.assertNotNull(newDevice.getId());
@@ -225,7 +227,8 @@ public class DevicesTest {
         AuthenticationMechanismServiceModel authModel = new AuthenticationMechanismServiceModel(AuthenticationType.SelfSinged);
 
         TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, null, tags, true);
-        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, null, twin, authModel, null);
+        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, false, null,
+                twin, authModel, null);
         DeviceServiceModel newDevice = deviceService.createAsync(device).toCompletableFuture().get();
 
         Assert.assertNotNull(newDevice.getId());
@@ -246,7 +249,8 @@ public class DevicesTest {
         }};
         TwinProperties properties = new TwinProperties(null, null);
         TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, properties, tags, true);
-        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, null, twin, null, null);
+        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, false, null,
+                twin, null, null);
         DeviceServiceModel newDevice = deviceService.createAsync(device).toCompletableFuture().get();
         Assert.assertNotNull(newDevice.getId());
         Assert.assertTrue(deviceService.deleteAsync(newDevice.getId()).toCompletableFuture().get());
@@ -280,7 +284,8 @@ public class DevicesTest {
         };
         TwinProperties properties = new TwinProperties(desired, reported);
         TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, properties, tags, true);
-        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, null, twin, null, null);
+        DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, false, null,
+                twin, null, null);
         DeviceServiceModel newDevice = deviceService.createOrUpdateAsync(device.getId(), device, cacheUpdateCallBack).toCompletableFuture().get();
         TwinServiceModel newTwin = newDevice.getTwin();
         HashMap<String, Object> configMap = (HashMap) newTwin.getProperties().getDesired().get("Config");
@@ -296,7 +301,8 @@ public class DevicesTest {
         String deviceId = randomDeviceId();
         String eTag = "etagxx==";
         TwinServiceModel twin = new TwinServiceModel(eTag, "MismatchedDeviceID", null, null, true);
-        DeviceServiceModel device = new DeviceServiceModel(eTag, "MismatchedDeviceID", 0, null, false, true, null, twin, null, null);
+        DeviceServiceModel device = new DeviceServiceModel(eTag, "MismatchedDeviceID", 0, null, false,
+                true, false, null, twin, null, null);
         deviceService.createOrUpdateAsync(deviceId, device, cacheUpdateCallBack).toCompletableFuture().get();
     }
 
@@ -306,7 +312,8 @@ public class DevicesTest {
         String deviceId = randomDeviceId();
         String eTag = "etagxx==";
         TwinServiceModel twin = new TwinServiceModel(eTag, "", null, null, true);
-        DeviceServiceModel device = new DeviceServiceModel(eTag, "", 0, null, false, true, null, twin, null, null);
+        DeviceServiceModel device = new DeviceServiceModel(eTag, "", 0, null, false, true, false, null, twin,
+                null, null);
         deviceService.createOrUpdateAsync(deviceId, device, cacheUpdateCallBack).toCompletableFuture().get();
     }
 
@@ -371,7 +378,8 @@ public class DevicesTest {
                 };
                 TwinProperties properties = new TwinProperties(desired, null);
                 TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, properties, tags, true);
-                DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, null, twin, null, null);
+                DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true,
+                        false, null, twin, null, null);
                 DeviceServiceModel newDevice = deviceService.createAsync(device).toCompletableFuture().get();
                 testDevices.add(newDevice);
                 System.out.println(deviceId + " created");

--- a/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/JobsTest.java
+++ b/iothub-manager/test/com/microsoft/azure/iotsolutions/iothubmanager/services/JobsTest.java
@@ -239,7 +239,8 @@ public class JobsTest {
                 };
                 TwinProperties properties = new TwinProperties(desired, null);
                 TwinServiceModel twin = new TwinServiceModel(eTag, deviceId, properties, tags, true);
-                DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true, null, twin, null, null);
+                DeviceServiceModel device = new DeviceServiceModel(eTag, deviceId, 0, null, false, true,
+                        false, null, twin, null, null);
                 DeviceServiceModel newDevice = deviceService.createAsync(device).toCompletableFuture().get();
                 testDevices.add(newDevice);
                 System.out.println(deviceId + " created");


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [x] The change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

# Description of the change
Currently there is no way in remote monitoring to add an edge device. This allows us to create edge devices and also report whether the device that was looked up is an edge device or not.

Note: Due to the way the SDK is setup (getTwin doesn't return and instead modifies the state passed in and also private setters on DeviceTwinDevice creating a unit test was extremely difficult if not impossible. I needed to use mockito doAnswer but would have also had to bring in something to mock static). We can circle back if this is critical.

# Motivation for the change
Allows remote monitoring to have a better story around edge devices that doesn't require a user to use Azure portal to initially create the device.

This is the same as https://github.com/Azure/remote-monitoring-services-dotnet/pull/165 but for java.