### PR TITLE
Add additional unmanaged resources

### DIFF
--- a/device-telemetry/build.sbt
+++ b/device-telemetry/build.sbt
@@ -54,6 +54,8 @@ lazy val commonSettings = Seq(
   publishArtifact in(Compile, packageSrc) := true,
   publishArtifact in(Compile, packageBin) := true,
 
+  unmanagedResourceDirectories in Compile += baseDirectory.value / "app",
+
   // Test
   testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
 


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
The resources directory where the email template is not in the default conf directory which play framework treats as unmanaged resources and thus copies it over. Because of this we need to add the additional directory the same way config micro service does it.

# Motivation for the change
Without this change the container will not have the necessary email template and thus fail on startup.