### PR TITLE
Fix retry logic for deployment not seeding correctly

### DIFF
--- a/config/app/com/microsoft/azure/iotsolutions/uiconfig/services/Seed.java
+++ b/config/app/com/microsoft/azure/iotsolutions/uiconfig/services/Seed.java
@@ -87,11 +87,17 @@ public class Seed implements ISeed {
             this.seedAsync(this.config.getSeedTemplate());
             this.log.info("Seed end");
             this.setCompletedFlagAsync().toCompletableFuture().get();
-            this.mutex.leaveAsync(SeedCollectionId, MutexKey).toCompletableFuture().get();
+            this.log.info("Seed completed flag set");
             return CompletableFuture.completedFuture(Optional.empty());
         } catch (Exception e) {
             log.error("Seed failed", e);
             throw new ExternalDependencyException("Seed failed", e);
+        } finally {
+            try {
+                this.mutex.leaveAsync(SeedCollectionId, MutexKey).toCompletableFuture().get();
+            } catch (Exception ex) {
+                this.log.warn("mutex.LeaveAsync failed");
+            }
         }
     }
 


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
The seed retry when failed was not releasing the mutex. Because of this the 2nd attempt would see a conflict, and exit gracefully. Now we make sure the mutex is released in a finally block so that the second attempt goes through.

I verified a standard deployment with this change where I saw the first seed fail. And the second one succeed.

.Net version https://github.com/Azure/remote-monitoring-services-dotnet/pull/195