### PR TITLE
Fix key not found exception when viewing device groups

### DIFF
--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Devices.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Devices.java
@@ -165,9 +165,9 @@ public final class Devices implements IDevices {
                             final Map<String, TwinServiceModel> twinsMap = twins.getLeft();
                             final String responseContinuationToken = twins.getRight();
 
-                            devices = devices.stream().filter(device -> twinsMap.containsKey(device
-                                    .getDeviceId()))
-                                    .collect(Collectors.toCollection(ArrayList::new));
+                            devices = devices.stream()
+                                             .filter(device -> twinsMap.containsKey(device.getDeviceId()))
+                                             .collect(Collectors.toCollection(ArrayList::new));
                             final Set<String> connectedEdgeDevices = this.getConnectedEdgeDevices(devices,
                                     twinsMap).toCompletableFuture().get();
 


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
When checking if an edge device is connected or not we look up the status of the device in the device twin map. However, when we are only viewing a subset of devices (using a group query), the twin map may not have all the devices that were returned in the getDevicesAsync call. This leads to a key not found exception.

The fix is to filter our devices list to only be the devices that were returned in the query (all the devices that are in the twin map).

# Motivation for the change
Viewing list of devices in groups is broken.  This fixes this for both devices page and deployments page.
