### PR TITLE
ADM Edge query fix and other enhancements

### DIFF
--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceStatus/EdgeDeviceStatusQueries.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceStatus/EdgeDeviceStatusQueries.java
@@ -10,14 +10,19 @@ public class EdgeDeviceStatusQueries {
     public static Map<DeviceStatusQueries.QueryType, String> queries =
             new HashMap<DeviceStatusQueries.QueryType,String>() {
         {
-            put(DeviceStatusQueries.QueryType.APPLIED, "select * from devices.modules where moduleId = '$edgeAgent' " +
-                    "and configurations.[[%s]].status = 'Applied'");
-            put(DeviceStatusQueries.QueryType.SUCCESSFUL, "select * from devices.modules where moduleId = '$edgeAgent' " +
-                    "and properties.desired.$version = properties.reported.lastDesiredVersion and " +
-                    "properties.reported.lastDesiredStatus.code = 200");
-            put(DeviceStatusQueries.QueryType.FAILED, "select * from devices WHERE " +
-                    "properties.reported.firmware.fwUpdateStatus='Error' AND " +
-                    "properties.reported.firmware.type='IoTDevKit'");
+            put(DeviceStatusQueries.QueryType.APPLIED, "SELECT * from devices.modules WHERE " +
+                    " moduleId = '$edgeAgent' " +
+                    " AND configurations.[[%s]].status = 'Applied'");
+            put(DeviceStatusQueries.QueryType.SUCCESSFUL, "SELECT * from devices.modules WHERE " +
+                    " moduleId = '$edgeAgent' " +
+                    " AND configurations.[[%s]].status = 'Applied' " +
+                    " AND properties.desired.$version = properties.reported.lastDesiredVersion " +
+                    " AND properties.reported.lastDesiredStatus.code = 200");
+            put(DeviceStatusQueries.QueryType.FAILED, "SELECT * from devices WHERE " +
+                    " moduleId = '$edgeAgent' " +
+                    " AND configurations.[[%s]].status = 'Applied' " +
+                    " AND properties.desired.$version = properties.reported.lastDesiredVersion " +
+                    " AND properties.reported.lastDesiredStatus.code != 200");
         }
     };
 }

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceStatus/FirmwareStatusQueries.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceStatus/FirmwareStatusQueries.java
@@ -10,14 +10,16 @@ public class FirmwareStatusQueries {
     public static Map<DeviceStatusQueries.QueryType, String> queries =
             new HashMap<DeviceStatusQueries.QueryType, String>() {
         {
-            put(DeviceStatusQueries.QueryType.APPLIED, "select * from devices where " +
-                    "configurations.[[%s]].status = 'Applied'");
-            put(DeviceStatusQueries.QueryType.SUCCESSFUL, "select * FROM devices WHERE " +
-                    "properties.reported.firmware.fwUpdateStatus='Current' AND " +
-                    "properties.reported.firmware.type='IoTDevKit'");
-            put(DeviceStatusQueries.QueryType.FAILED, "select * FROM devices WHERE " +
-                    "properties.reported.firmware.fwUpdateStatus='Error' AND " +
-                    "properties.reported.firmware.type='IoTDevKit'");
+            put(DeviceStatusQueries.QueryType.APPLIED, "SELECT * from devices WHERE " +
+                    " configurations.[[%s]].status = 'Applied'");
+            put(DeviceStatusQueries.QueryType.SUCCESSFUL, "SELECT * FROM devices WHERE " +
+                    " configurations.[[%s]].status = 'Applied'" +
+                    " AND properties.reported.firmware.fwUpdateStatus='Current' " +
+                    " AND properties.reported.firmware.type='IoTDevKit'");
+            put(DeviceStatusQueries.QueryType.FAILED, "SELECT * FROM devices WHERE " +
+                    " configurations.[[%s]].status = 'Applied'" +
+                    " AND properties.reported.firmware.fwUpdateStatus='Error' " +
+                    " AND properties.reported.firmware.type='IoTDevKit'");
         }
     };
 }

--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeploymentMetricsApiModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeploymentMetricsApiModel.java
@@ -5,6 +5,7 @@ package com.microsoft.azure.iotsolutions.iothubmanager.webservice.v1.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentMetrics;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.DeploymentStatus;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,8 +15,8 @@ public class DeploymentMetricsApiModel {
 
     private static final String APPLIED_METRICS_KEY = "appliedCount";
     private static final String TARGETED_METRICS_KEY = "targetedCount";
-    private static final String SUCCESEEDED_METRICS_KEY = "succeededCount";
-    private static final String FAILED_METRICS_KEY = "failedCount";
+    private static final String SUCCESEEDED_METRICS_KEY = "reportedSuccessfulCount";
+    private static final String FAILED_METRICS_KEY = "reportedFailedCount";
     private static final String PENDING_METRICS_KEY = "pendingCount";
 
     private Map<String, Long> systemMetrics;
@@ -45,8 +46,8 @@ public class DeploymentMetricsApiModel {
         if (metricsServiceModel == null) return;
 
         this.customMetrics = metricsServiceModel.getCustomMetrics();
-        this.systemMetrics = metricsServiceModel.getSystemMetrics() != null ?
-                metricsServiceModel.getSystemMetrics() : this.systemMetrics;
+        this.systemMetrics = MapUtils.isEmpty(metricsServiceModel.getSystemMetrics()) ?
+                                            metricsServiceModel.getSystemMetrics() : this.systemMetrics;
         this.deviceStatuses = metricsServiceModel.getDeviceStatuses();
 
         if (metricsServiceModel.getDeviceMetrics() != null) {


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] All new and existing tests passed.
- [ ] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
By default Edge Deployments have SystemMetrics containing keys to the "reportedSuccessfulCount" and "reportedFailedCount". In the implementation, we also count # of devices succeeded and failed which are named "succeededCount" and "failedCount". The fix is to have a consistent naming convention.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
...
