### PR TITLE
Reference timer to prevent GC

### DIFF
--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/RecurringTasksAgent/Agent.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/RecurringTasksAgent/Agent.java
@@ -26,6 +26,7 @@ public class Agent implements IRecurringTasksAgent {
 
     private final IDeviceProperties cache;
     private static final Logger.ALogger log = Logger.of(Agent.class);
+    private Timer cacheUpdateTimer;
 
     @Inject
     public Agent(IDeviceProperties cache) {
@@ -62,8 +63,8 @@ public class Agent implements IRecurringTasksAgent {
     private void scheduleDevicePropertiesCacheUpdate() {
         try {
             this.log.info("Scheduling a DeviceProperties cache update");
-            Timer timer = new Timer("DeviceProperties cache update", true);
-            timer.schedule(new TimerTask() {
+            this.cacheUpdateTimer = new Timer("DeviceProperties cache update", true);
+            this.cacheUpdateTimer.schedule(new TimerTask() {
                 @Override
                 public void run() {
                     updateDevicePropertiesCache();


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
The timer that is created is not referenced anywhere so it has potential to be garbage collected. If it is GCed before firing then it never gets scheduled again leading to this recurring task dying.

# Motivation for the change
Tags.IsSimulated was missing on new deployments