### PR TITLE
Return null for EndTime for a job when job is still running

### DIFF
--- a/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/JobServiceModel.java
+++ b/iothub-manager/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/JobServiceModel.java
@@ -31,8 +31,20 @@ public class JobServiceModel {
         this.queryCondition = jobResult.getQueryCondition();
         this.createdTimeUtc = jobResult.getCreatedTime();
         this.startTimeUtc = jobResult.getStartTime();
-        this.endTimeUtc = jobResult.getEndTime();
+        this.endTimeUtc = null;
         this.maxExecutionTimeInSeconds = jobResult.getMaxExecutionTimeInSeconds();
+
+        switch (JobStatus.valueOf(jobResult.getJobStatus().toString()))
+        {
+            case completed:
+            case failed:
+            case cancelled:
+                this.endTimeUtc = jobResult.getEndTime();
+                break;
+            default:
+                break;
+        }
+
         this.jobType = JobType.fromAzureJobType(jobResult.getJobType());
         this.jobStatus = JobStatus.fromAzureJobStatus(jobResult.getJobStatus());
 


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [ ] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
The IoT Hub returns a date that is always 12/30/9999 when the job hasn't completed yet. 
This fix returns null for the end time when a job hasn't yet finished running. 

![image](https://user-images.githubusercontent.com/3317135/39500769-bc9e3a22-4d6b-11e8-9c1e-5219f2b1fc41.png)


# Motivation for the change

Issue - [here](https://github.com/Azure/remote-monitoring-services-java/issues/39)
 Dot net pull request - [here](https://github.com/Azure/iothub-manager-dotnet/pull/117)
...
