### PR TITLE
Update run.cmd to reflect key-vault changes

### DIFF
--- a/device-simulation/scripts/docker/run.cmd
+++ b/device-simulation/scripts/docker/run.cmd
@@ -21,10 +21,11 @@ IF %ERRORLEVEL% NEQ 0 GOTO FAIL
 :: Start the application
 echo Starting Device Simulation ...
 docker run -it -p 9003:9003 ^
-    -e PCS_IOTHUB_CONNSTRING ^
-    -e PCS_STORAGEADAPTER_WEBSERVICE_URL="http://host.docker.internal:9022/v1" ^
-    -e PCS_SUBSCRIPTION_ID ^
-    %DOCKER_IMAGE%:testing
+-e PCS_KEYVAULT_NAME ^
+    -e PCS_AAD_APPID ^
+    -e PCS_AAD_APPSECRET ^
+    -e PCS_STORAGEADAPTER_WEBSERVICE_URL=http://service.docker.internal:9022/v1 ^
+    %DOCKER_IMAGE%:1.0.5
 
 :: - - - - - - - - - - - - - -
 goto :END

--- a/device-simulation/scripts/docker/run.cmd
+++ b/device-simulation/scripts/docker/run.cmd
@@ -21,7 +21,7 @@ IF %ERRORLEVEL% NEQ 0 GOTO FAIL
 :: Start the application
 echo Starting Device Simulation ...
 docker run -it -p 9003:9003 ^
--e PCS_KEYVAULT_NAME ^
+    -e PCS_KEYVAULT_NAME ^
     -e PCS_AAD_APPID ^
     -e PCS_AAD_APPSECRET ^
     -e PCS_STORAGEADAPTER_WEBSERVICE_URL=http://service.docker.internal:9022/v1 ^

--- a/device-simulation/scripts/docker/run.cmd
+++ b/device-simulation/scripts/docker/run.cmd
@@ -24,7 +24,7 @@ docker run -it -p 9003:9003 ^
     -e PCS_KEYVAULT_NAME ^
     -e PCS_AAD_APPID ^
     -e PCS_AAD_APPSECRET ^
-    -e PCS_STORAGEADAPTER_WEBSERVICE_URL=http://service.docker.internal:9022/v1 ^
+    -e PCS_STORAGEADAPTER_WEBSERVICE_URL=http://host.docker.internal:9022/v1 ^
     %DOCKER_IMAGE%:1.0.5
 
 :: - - - - - - - - - - - - - -


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] All new and existing tests passed.
- [ ] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
On a local native deployment, device-simulation runs as a Docker container. The service needs to talk to StorageAdapter service that runs on the docker host. The correct URL to communicate with host service (http://host.docker.internal:9022/v1) & NOT http://service.docker.internal:9022/v1.


# Motivation for the change
Bug fix for
https://github.com/Azure/remote-monitoring-services-java/issues/140
...
